### PR TITLE
Fix security token in cart AJAX and guard payment option listeners

### DIFF
--- a/inc/edit_cart_page.php
+++ b/inc/edit_cart_page.php
@@ -14,9 +14,11 @@ add_action('woocommerce_proceed_to_checkout', 'checkout_at_admin_button', 20);
 add_action('wp_footer', 'send_cart_data_via_webhook');
 function send_cart_data_via_webhook() {
     if (is_cart()) {
+        $nonce = wp_create_nonce('get_cart_contents_nonce');
         ?>
         <script type="text/javascript">
             jQuery(document).ready(function($) {
+                var getCartNonce = '<?php echo $nonce; ?>';
                 $('#checkout_at_admin').click(function(e) {
                     e.preventDefault();
 
@@ -24,7 +26,8 @@ function send_cart_data_via_webhook() {
                         url: '<?php echo admin_url('admin-ajax.php'); ?>',
                         type: 'POST',
                         data: {
-                            action: 'get_cart_contents'
+                            action: 'get_cart_contents',
+                            security: getCartNonce
                         },
                         success: function(response) {
                             var modifiedResponse = {};
@@ -91,6 +94,7 @@ function send_cart_data_via_webhook() {
 add_action('wp_ajax_get_cart_contents', 'get_cart_contents');
 add_action('wp_ajax_nopriv_get_cart_contents', 'get_cart_contents');
 function get_cart_contents() {
+    check_ajax_referer('get_cart_contents_nonce', 'security');
     $cart = WC()->cart->get_cart();
     wp_send_json($cart);
 }

--- a/inc/preferred_dd_and_mf_option.php
+++ b/inc/preferred_dd_and_mf_option.php
@@ -121,6 +121,7 @@ function add_custom_datepicker_script()
     });
 
     var selectMonthlyFeeOption = document.getElementById('monthlyfee_payment_option');
+    if (selectMonthlyFeeOption) {
     selectMonthlyFeeOption.addEventListener("change", function() {
         var selectedOption = this.value;
         var priceChangeMessage = '';
@@ -176,6 +177,7 @@ function add_custom_datepicker_script()
     var newCartTotal = cartTotal - priceChangeAmount;
     document.querySelector('.order-total .woocommerce-Price-amount bdi').textContent = newCartTotal.toLocaleString("jp-JP", {style:"currency", currency:"JPY"});
     });
+    }
 
     </script>
 

--- a/inc/preferred_dd_option.php
+++ b/inc/preferred_dd_option.php
@@ -104,7 +104,8 @@ function add_custom_datepicker_script()
         });
     });
 
-    var selectMonthlyFeeOption = document.getElementById('monthlyfee_payment_option')  || 'blank';
+    var selectMonthlyFeeOption = document.getElementById('monthlyfee_payment_option');
+    if (selectMonthlyFeeOption) {
     selectMonthlyFeeOption.addEventListener("change", function() {
         var selectedOption = this.value;
         var priceChangeMessage = '';
@@ -160,6 +161,7 @@ function add_custom_datepicker_script()
     var newCartTotal = cartTotal - priceChangeAmount;
     document.querySelector('.order-total .woocommerce-Price-amount bdi').textContent = newCartTotal.toLocaleString("jp-JP", {style:"currency", currency:"JPY"});
     });
+    }
 
     </script>
 


### PR DESCRIPTION
## Summary
- Guard monthly-fee option scripts to avoid addEventListener on null elements
- Add nonce handling to get_cart_contents AJAX endpoint to fix invalid security token popup

## Testing
- `php -l inc/preferred_dd_and_mf_option.php`
- `php -l inc/preferred_dd_option.php`
- `php -l inc/edit_cart_page.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4fe6abef4832cb3c3f944c73ac4c5